### PR TITLE
fix/adds missing space

### DIFF
--- a/src/AlpinimationsServiceProvider.php
+++ b/src/AlpinimationsServiceProvider.php
@@ -40,6 +40,7 @@ class AlpinimationsServiceProvider extends ServiceProvider
 
     protected function renderAlpinimation($animationName, $extra = "")
     {
+        $extra = $extra ? $extra . " " : $extra;
         return "<?php echo \"$extra\"; echo view('alpinimation::' . $animationName)->render(); ?>";
     }
 }


### PR DESCRIPTION
Hey man,

I just realised that there is a space missing between the `x-show`-script block and the animations.

Pictures take from Firefox Sourcecode-view:
![beofre](https://user-images.githubusercontent.com/10073766/128947782-ff3b63d0-91ee-4cfa-a5a7-0cd07a524e6d.png)
_before_


![after](https://user-images.githubusercontent.com/10073766/128947816-b2693711-ce56-4f8d-baaa-1fb268fe9d9e.png)
_after_


![w3c](https://user-images.githubusercontent.com/10073766/128947826-24064d5f-2f25-486f-95ca-37be0667251e.png)
_w3c-cehcker_


changes
---
- adds a missing space between the `x-show`-attribute and the animations-code (blade-file)